### PR TITLE
Add 'hydrator' mutator to the list of default mutators

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	setupLog                       = ctrl.Log.WithName("setup")
 	defaultAuthenticatorsAvailable = [...]string{"noop", "unauthorized", "anonymous", "oauth2_client_credentials", "oauth2_introspection", "jwt"}
 	defaultAuthorizersAvailable    = [...]string{"allow", "deny", "keto_engine_acp_ory"}
-	defaultMutatorsAvailable       = [...]string{"noop", "id_token", "header", "cookie"}
+	defaultMutatorsAvailable       = [...]string{"noop", "id_token", "header", "cookie", "hydrator"}
 )
 
 const (


### PR DESCRIPTION
Adds a new mutator introduced in [oathkeeper/#240](https://github.com/ory/oathkeeper/pull/240) to the default list of mutators used for validation.