### PR TITLE
fix: upstream should not be required in Rule CRD

### DIFF
--- a/config/crd/bases/oathkeeper.ory.sh_rules.yaml
+++ b/config/crd/bases/oathkeeper.ory.sh_rules.yaml
@@ -128,7 +128,6 @@ spec:
               type: object
           required:
           - match
-          - upstream
           type: object
         status:
           description: RuleStatus defines the observed state of Rule


### PR DESCRIPTION
As indicated here https://github.com/ory/oathkeeper-maester/issues/43 upstream should not be required in CRD for Rules