### PR TITLE
feat: including option to scope manager to namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ Usage example: `./manager [--global-flags] mode [--mode-flags]`
 | :--- | :--- | :---: |
 | **rulesFilePath** | Path to the file with converted Oathkeeper rules | `/etc/config/access-rules.json` |
 
+### Environment variables
+
+| Name | Description | Default values |
+| :--- | :--- | :---: |
+| **NAMESPACE** | Namespace option to scope Oathkeeper maester to one namespace only - useful for running several instances in one cluster. Defaults to "" which means that there is no namespace scope. | `` |
+

--- a/main.go
+++ b/main.go
@@ -94,6 +94,8 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		// Defaults to "" which means all namespaces
+		Namespace: os.Getenv("NAMESPACE"),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This PR would allow to run Oathkeeper maester namespace-scoped. 

To use this option one has to change RBAC configuration in the helm chart:
-  change ClusterRole to Role and ClusterRoleBinding to RoleBinding 
- add the environment variable ```NAMESPACE```

If no environment variable is given, the default is "" which means all namespaces in Kubernetes.

If you want, we can also do a PR to the helm chart repo.